### PR TITLE
Add option to exclude roles

### DIFF
--- a/lang/en/block_completion_progress.php
+++ b/lang/en/block_completion_progress.php
@@ -99,3 +99,5 @@ $string['why_show_precentage_help'] = '<p>It is possible to show an overall perc
 $string['why_use_icons'] = 'Why you might want to use icons?';
 $string['why_use_icons_help'] = '<p>You may wish to add tick and cross icons in the Completion Progress to make this block more visually accessible for students with colour-blindness.</p><p>It may also make the meaning of the block clearer if you believe colours are not intuitive, either for cultural or personal reasons.</p>';
 $string['wrapafter'] = 'When wrapping, limit rows to';
+$string['roles_to_exclude'] = 'Roles to not display and not use and the block';
+$string['roles_to_exclude_desc'] = 'Roles list to not display or not use in this block and in the overview report. If an user owns one of theses roles the user will not appear in the block informations and his progress will not be displayed.';

--- a/overview.php
+++ b/overview.php
@@ -172,8 +172,10 @@ $rolestoexclude = get_config('block_completion_progress' ,'roles_to_exclude');
 $sql = "SELECT DISTINCT r.id, r.name, r.shortname
           FROM {role} r, {role_assignments} a
          WHERE a.contextid = :contextid
-           AND r.id = a.roleid
-           AND r.id not in ($rolestoexclude)";
+           AND r.id = a.roleid";
+if ($rolestoexclude != "") {
+    $sql .= " AND r.id not in ($rolestoexclude)";
+}
 $params = array('contextid' => $context->id);
 $roles = role_fix_names($DB->get_records_sql($sql, $params), $context);
 $rolestodisplay = array(0 => get_string('allparticipants'));
@@ -206,9 +208,11 @@ $sql = "SELECT DISTINCT $picturefields, COALESCE(l.timeaccess, 0) AS lastonlinet
           FROM {user} u
           JOIN {role_assignments} a ON (a.contextid = :contextid AND a.userid = u.id $rolewhere)
           $groupjoin
-    LEFT JOIN {user_lastaccess} l ON (l.courseid = :courseid AND l.userid = u.id)
-     WHERE a.userid not in 
+    LEFT JOIN {user_lastaccess} l ON (l.courseid = :courseid AND l.userid = u.id)";
+if ($rolestoexclude != "") {
+    $sql .= " WHERE a.userid not in 
         (SELECT userid FROM {role_assignments} WHERE contextid = :subcontextid AND roleid IN ($rolestoexclude))";
+}
 $params['contextid'] = $context->id;
 $params['subcontextid'] = $context->id;
 $params['courseid'] = $course->id;

--- a/overview.php
+++ b/overview.php
@@ -168,10 +168,12 @@ if (!empty($groups) || !empty($groupings)) {
 }
 
 // Output the roles menu.
+$rolestoexclude = get_config('block_completion_progress' ,'roles_to_exclude');
 $sql = "SELECT DISTINCT r.id, r.name, r.shortname
           FROM {role} r, {role_assignments} a
          WHERE a.contextid = :contextid
-           AND r.id = a.roleid";
+           AND r.id = a.roleid
+           AND r.id not in ($rolestoexclude)";
 $params = array('contextid' => $context->id);
 $roles = role_fix_names($DB->get_records_sql($sql, $params), $context);
 $rolestodisplay = array(0 => get_string('allparticipants'));
@@ -204,8 +206,11 @@ $sql = "SELECT DISTINCT $picturefields, COALESCE(l.timeaccess, 0) AS lastonlinet
           FROM {user} u
           JOIN {role_assignments} a ON (a.contextid = :contextid AND a.userid = u.id $rolewhere)
           $groupjoin
-     LEFT JOIN {user_lastaccess} l ON (l.courseid = :courseid AND l.userid = u.id)";
+    LEFT JOIN {user_lastaccess} l ON (l.courseid = :courseid AND l.userid = u.id)
+     WHERE a.userid not in 
+        (SELECT userid FROM {role_assignments} WHERE contextid = :subcontextid AND roleid IN ($rolestoexclude))";
 $params['contextid'] = $context->id;
+$params['subcontextid'] = $context->id;
 $params['courseid'] = $course->id;
 $userrecords = $DB->get_records_sql($sql, $params);
 if (get_config('block_completion_progress', 'showinactive') !== "1") {

--- a/settings.php
+++ b/settings.php
@@ -102,4 +102,10 @@ if ($ADMIN->fulltree) {
         '',
         DEFAULT_COMPLETIONPROGRESS_FORCEICONSINBAR)
     );
+    $settings->add(new admin_setting_pickroles(
+        'block_completion_progress/roles_to_exclude',
+        get_string('roles_to_exclude', 'block_completion_progress'),
+        get_string('roles_to_exclude_desc', 'block_completion_progress'),
+        null
+    ));
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2020081000;
+$plugin->version   = 2020111000;
 $plugin->requires  = 2018051700;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'Version for Moodle 3.5 onwards';


### PR DESCRIPTION
I try to add a feature in order to exclude some roles in the block use.
With this option, it is possible to not display some roles in the block and the overview page. If a user owns one of the selected roles the user will not be displayed.
Feel free to edit this PR.