### PR TITLE
Fix/missing progress bar

### DIFF
--- a/css.php
+++ b/css.php
@@ -23,6 +23,7 @@
  */
 
 require_once(__DIR__ . '/../../config.php');
+require_once($CFG->libdir.'/filelib.php');
 
 $cachevalue = optional_param('v', -1, PARAM_INT);
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2020081000;
+$plugin->version   = 2021021800;
 $plugin->requires  = 2019111800;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'Version for Moodle 3.8 onwards';


### PR DESCRIPTION
We were experiencing the same issue as #69 and tracked it down to the send_file() and send_content_uncached() called in css.php not being defined as the filelib is not being loaded. Requiring filelib fixes the issue.

Also found the version number wasn't changed when the plugin was last updated, so bumped the version.