### PR TITLE
Fix overview page for non admin users

### DIFF
--- a/overview.php
+++ b/overview.php
@@ -104,7 +104,7 @@ if (has_capability('moodle/site:accessallgroups', $context)) {
         $groupoptions[0] = get_string('allparticipants');
     }
 } else {
-    $allgroups = groups_get_all_groups($course, $USER->id);
+    $allgroups = groups_get_all_groups($course->id, $USER->id);
     $allgroupings = [];
 }
 foreach ($allgroups as $rec) {


### PR DESCRIPTION
There was a small issue with the new implementation of the overview page. Non admin users could not access it because the function call to groups_get_all_groups was wrong in that branch.