### PR TITLE
Use a short date when downloading.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Deploy moodle-plugin-ci
       run: |
-        composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+        composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
         echo $(cd ci/bin; pwd) >> $GITHUB_PATH
         echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
         sudo locale-gen en_AU.UTF-8

--- a/backup/moodle2/restore_completion_progress_block_task.class.php
+++ b/backup/moodle2/restore_completion_progress_block_task.class.php
@@ -43,15 +43,15 @@ class restore_completion_progress_block_task extends restore_block_task {
         // Get restored course id.
         $courseid = $this->get_courseid();
 
-        if ($configdata = $DB->get_field('block_instances', 'configdata', array('id' => $id))) {
+        if ($configdata = $DB->get_field('block_instances', 'configdata', ['id' => $id])) {
             $config = (array)unserialize(base64_decode($configdata));
-            $newactivities = array();
+            $newactivities = [];
             $newgroup = '0';
 
             if (isset($config['selectactivities'])) {
                 // Translate the old config information to the target course values.
                 foreach ($config['selectactivities'] as $value) {
-                    $matches = array();
+                    $matches = [];
                     preg_match('/(.+)-(\d+)/', $value, $matches);
                     if (!empty($matches)) {
                         $module = $matches[1];
@@ -88,7 +88,7 @@ class restore_completion_progress_block_task extends restore_block_task {
             $config['selectactivities'] = $newactivities;
             $config['group'] = $newgroup;
             $configdata = base64_encode(serialize((object)$config));
-            $DB->set_field('block_instances', 'configdata', $configdata, array('id' => $id));
+            $DB->set_field('block_instances', 'configdata', $configdata, ['id' => $id]);
         }
     }
 
@@ -110,7 +110,7 @@ class restore_completion_progress_block_task extends restore_block_task {
      * @return array An empty array
      */
     public function get_fileareas() {
-        return array();
+        return [];
     }
 
     /**
@@ -119,7 +119,7 @@ class restore_completion_progress_block_task extends restore_block_task {
      * @return array An empty array
      */
     public function get_configdata_encoded_attributes() {
-        return array();
+        return [];
     }
 
     /**
@@ -128,7 +128,7 @@ class restore_completion_progress_block_task extends restore_block_task {
      * @return array An empty array
      */
     public static function define_decode_contents() {
-        return array();
+        return [];
     }
 
     /**
@@ -137,6 +137,6 @@ class restore_completion_progress_block_task extends restore_block_task {
      * @return array An empty array
      */
     public static function define_decode_rules() {
-        return array();
+        return [];
     }
 }

--- a/block_completion_progress.php
+++ b/block_completion_progress.php
@@ -94,12 +94,12 @@ class block_completion_progress extends block_base {
      * @return array
      */
     public function applicable_formats() {
-        return array(
+        return [
             'course-view'    => true,
             'site'           => true,
             'mod'            => false,
-            'my'             => true
-        );
+            'my'             => true,
+        ];
     }
 
     /**
@@ -115,7 +115,7 @@ class block_completion_progress extends block_base {
         $this->content = new stdClass;
         $this->content->text = '';
         $this->content->footer = '';
-        $barinstances = array();
+        $barinstances = [];
 
         // Guests do not have any progress. Don't show them the block.
         if (!isloggedin() || isguestuser()) {
@@ -213,7 +213,7 @@ class block_completion_progress extends block_base {
 
             // Output the Progress Bar.
             if (!empty($blockprogresses)) {
-                $courselink = new moodle_url('/course/view.php', array('id' => $course->id));
+                $courselink = new moodle_url('/course/view.php', ['id' => $course->id]);
                 $linktext = html_writer::tag('h3', s(format_string($course->$coursenametoshow)));
                 $this->content->text .= html_writer::link($courselink, $linktext);
             }
@@ -286,14 +286,14 @@ class block_completion_progress extends block_base {
         if (has_capability('block/completion_progress:showbar', $this->context)) {
             $this->content->text .= $output->render($progress);
         }
-        $barinstances = array($this->instance->id);
+        $barinstances = [$this->instance->id];
 
         // Allow teachers to access the overview page.
         if (has_capability('block/completion_progress:overview', $this->context)) {
-            $parameters = array('instanceid' => $this->instance->id, 'courseid' => $COURSE->id);
+            $parameters = ['instanceid' => $this->instance->id, 'courseid' => $COURSE->id];
             $url = new moodle_url('/blocks/completion_progress/overview.php', $parameters);
             $label = get_string('overview', 'block_completion_progress');
-            $options = array('class' => 'overviewButton');
+            $options = ['class' => 'overviewButton'];
             $this->content->text .= $OUTPUT->single_button($url, $label, 'get', $options);
         }
 

--- a/classes/completion_progress.php
+++ b/classes/completion_progress.php
@@ -622,7 +622,7 @@ class completion_progress implements \renderable {
         }
 
         // Queries to deliver instance IDs of activities with submissions by user.
-        $queries = array (
+        $queries = [
             [
                 // Assignments with individual submission, or groups requiring a submission per user,
                 // or ungrouped users in a group submission situation.
@@ -736,7 +736,7 @@ class completion_progress implements \renderable {
                     'gmavg' => QUIZ_GRADEAVERAGE,
                 ],
             ],
-        );
+        ];
 
         $this->submissions = [];
         foreach ($queries as $spec) {

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -63,25 +63,25 @@ class renderer extends plugin_renderer_base {
             return get_string('no_visible_activities_message', 'block_completion_progress');
         }
 
-        $alternatelinks = array(
-            'assign' => array(
+        $alternatelinks = [
+            'assign' => [
                 'url' => '/mod/assign/view.php?id=:cmid&action=grade&userid=:userid',
                 'capability' => 'mod/assign:grade',
-            ),
-            'feedback' => array(
+            ],
+            'feedback' => [
                 // Breaks if anonymous feedback is collected.
                 'url' => '/mod/feedback/show_entries.php?id=:cmid&do_show=showoneentry&userid=:userid',
                 'capability' => 'mod/feedback:viewreports',
-            ),
-            'lesson' => array(
+            ],
+            'lesson' => [
                 'url' => '/mod/lesson/report.php?id=:cmid&action=reportdetail&userid=:userid',
                 'capability' => 'mod/lesson:viewreports',
-            ),
-            'quiz' => array(
+            ],
+            'quiz' => [
                 'url' => '/mod/quiz/report.php?id=:cmid&mode=overview',
                 'capability' => 'mod/quiz:viewreports',
-            ),
-        );
+            ],
+        ];
 
         // Get relevant block instance settings or use defaults.
         if (get_config('block_completion_progress', 'forceiconsinbar') == 0) {
@@ -97,9 +97,9 @@ class renderer extends plugin_renderer_base {
         $displaynow = $orderby == completion_progress::ORDERBY_TIME;
         $showpercentage = $config->showpercentage ?? defaults::SHOWPERCENTAGE;
 
-        $rowoptions = array('style' => '');
-        $cellsoptions = array('style' => '');
-        $barclasses = array('barRow');
+        $rowoptions = ['style' => ''];
+        $cellsoptions = ['style' => ''];
+        $barclasses = ['barRow'];
 
         $content .= html_writer::start_div('barContainer', ['data-instanceid' => $instance]);
 
@@ -120,10 +120,10 @@ class renderer extends plugin_renderer_base {
             $displaynow = false;
         }
         if ($longbars == 'scroll') {
-            $leftpoly = html_writer::tag('polygon', '', array('points' => '30,0 0,15 30,30', 'class' => 'triangle-polygon'));
-            $rightpoly = html_writer::tag('polygon', '', array('points' => '0,0 30,15 0,30', 'class' => 'triangle-polygon'));
-            $content .= html_writer::tag('svg', $leftpoly, array('class' => 'left-arrow-svg', 'height' => '30', 'width' => '30'));
-            $content .= html_writer::tag('svg', $rightpoly, array('class' => 'right-arrow-svg', 'height' => '30', 'width' => '30'));
+            $leftpoly = html_writer::tag('polygon', '', ['points' => '30,0 0,15 30,30', 'class' => 'triangle-polygon']);
+            $rightpoly = html_writer::tag('polygon', '', ['points' => '0,0 30,15 0,30', 'class' => 'triangle-polygon']);
+            $content .= html_writer::tag('svg', $leftpoly, ['class' => 'left-arrow-svg', 'height' => '30', 'width' => '30']);
+            $content .= html_writer::tag('svg', $rightpoly, ['class' => 'right-arrow-svg', 'height' => '30', 'width' => '30']);
         }
         $barclasses[] = 'barMode' . ucfirst($longbars);
         if ($useicons) {
@@ -141,8 +141,8 @@ class renderer extends plugin_renderer_base {
                 $nowpos++;
             }
             $nowstring = get_string('now_indicator', 'block_completion_progress');
-            $leftarrowimg = $this->pix_icon('left', $nowstring, 'block_completion_progress', array('class' => 'nowicon'));
-            $rightarrowimg = $this->pix_icon('right', $nowstring, 'block_completion_progress', array('class' => 'nowicon'));
+            $leftarrowimg = $this->pix_icon('left', $nowstring, 'block_completion_progress', ['class' => 'nowicon']);
+            $rightarrowimg = $this->pix_icon('right', $nowstring, 'block_completion_progress', ['class' => 'nowicon']);
         }
 
         // Determine links to activities.
@@ -151,12 +151,12 @@ class renderer extends plugin_renderer_base {
                 array_key_exists($activities[$i]->type, $alternatelinks) &&
                 has_capability($alternatelinks[$activities[$i]->type]['capability'], $activities[$i]->context)
             ) {
-                $substitutions = array(
+                $substitutions = [
                     '/:courseid/' => $courseid,
                     '/:eventid/'  => $activities[$i]->instance,
                     '/:cmid/'     => $activities[$i]->id,
                     '/:userid/'   => $userid,
-                );
+                ];
                 $link = $alternatelinks[$activities[$i]->type]['url'];
                 $link = preg_replace(array_keys($substitutions), array_values($substitutions), $link);
                 $activities[$i]->link = $CFG->wwwroot.$link;
@@ -174,10 +174,10 @@ class renderer extends plugin_renderer_base {
 
             // A cell in the progress bar.
             $cellcontent = '';
-            $celloptions = array(
+            $celloptions = [
                 'class' => 'progressBarCell',
                 'data-info-ref' => 'progressBarInfo'.$instance.'-'.$userid.'-'.$activity->id,
-            );
+            ];
             if ($complete === 'submitted') {
                 $celloptions['class'] .= ' submittedNotComplete';
 
@@ -229,20 +229,20 @@ class renderer extends plugin_renderer_base {
         if ($showpercentage && !$simple) {
             $progress = $progress->get_percentage();
             $percentagecontent = get_string('progress', 'block_completion_progress').': '.$progress.'%';
-            $percentageoptions = array('class' => 'progressPercentage');
+            $percentageoptions = ['class' => 'progressPercentage'];
             $content .= html_writer::tag('div', $percentagecontent, $percentageoptions);
         }
 
         // Add the info box below the table.
-        $divoptions = array('class' => 'progressEventInfo',
-                            'id' => 'progressBarInfo'.$instance.'-'.$userid.'-info');
+        $divoptions = ['class' => 'progressEventInfo',
+                            'id' => 'progressBarInfo'.$instance.'-'.$userid.'-info'];
         $content .= html_writer::start_tag('div', $divoptions);
         if (!$simple) {
             $content .= get_string('mouse_over_prompt', 'block_completion_progress');
             $content .= ' ';
-            $attributes = array (
+            $attributes = [
                 'class' => 'accesshide progressShowAllInfo',
-            );
+            ];
             $content .= html_writer::link('#', get_string('showallinfo', 'block_completion_progress'), $attributes);
         }
         $content .= html_writer::end_tag('div');
@@ -258,14 +258,14 @@ class renderer extends plugin_renderer_base {
 
         foreach ($activities as $activity) {
             $completed = $completions[$activity->id] ?? null;
-            $divoptions = array('class' => 'progressEventInfo',
+            $divoptions = ['class' => 'progressEventInfo',
                                 'id' => 'progressBarInfo'.$instance.'-'.$userid.'-'.$activity->id,
-                                'style' => 'display: none;');
+                                'style' => 'display: none;'];
             $content .= html_writer::start_tag('div', $divoptions);
 
             $text = '';
             $text .= html_writer::empty_tag('img',
-                    array('src' => $activity->icon, 'class' => 'moduleIcon', 'alt' => '', 'role' => 'presentation'));
+                    ['src' => $activity->icon, 'class' => 'moduleIcon', 'alt' => '', 'role' => 'presentation']);
             $text .= $activity->name;
             if (!empty($activity->link) && (!empty($activity->available) || $simple)) {
                 $attrs = ['class' => 'action_link'];
@@ -299,10 +299,10 @@ class renderer extends plugin_renderer_base {
                     $altattribute .= '(' . $strsubmitted . ')';
                 }
             }
-            $content .= $this->pix_icon($icon, $altattribute, 'block_completion_progress', array('class' => 'iconInInfo'));
+            $content .= $this->pix_icon($icon, $altattribute, 'block_completion_progress', ['class' => 'iconInInfo']);
             $content .= html_writer::empty_tag('br');
             if ($activity->expected != 0) {
-                $content .= html_writer::start_tag('div', array('class' => 'expectedBy'));
+                $content .= html_writer::start_tag('div', ['class' => 'expectedBy']);
                 $content .= $strtimeexpected.': ';
                 $content .= userdate($activity->expected, $strdateformat, $CFG->timezone);
                 $content .= html_writer::end_tag('div');

--- a/classes/table/overview.php
+++ b/classes/table/overview.php
@@ -72,6 +72,7 @@ class overview extends \table_sql {
         $this->progress = $progress;
         $this->output = $PAGE->get_renderer('block_completion_progress');
         $this->strs['strftimedaydatetime'] = get_string('strftimedaydatetime', 'langconfig');
+        $this->strs['strftimedatetimeshort'] = get_string('strftimedatetimeshort', 'langconfig');
         $this->strs['indeterminate'] = get_string('indeterminate', 'block_completion_progress');
         $this->strs['never'] = get_string('never');
 
@@ -279,7 +280,7 @@ class overview extends \table_sql {
         if ($row->timeaccess == 0) {
             return $this->strs['never'];
         }
-        return userdate($row->timeaccess, $this->strs['strftimedaydatetime']);
+        return userdate($row->timeaccess, $this->strs[$this->is_downloading() ? 'strftimedatetimeshort' : 'strftimedaydatetime']);
     }
 
     /**

--- a/css.php
+++ b/css.php
@@ -34,12 +34,12 @@ $cachevalue = optional_param('v', -1, PARAM_INT);
 $css = '';
 
 // Emit colours configuration.
-$colours = array(
+$colours = [
     'completed' => 'completed_colour',
     'submittedNotComplete' => 'submittednotcomplete_colour',
     'notCompleted' => 'notCompleted_colour',
-    'futureNotCompleted' => 'futureNotCompleted_colour'
-);
+    'futureNotCompleted' => 'futureNotCompleted_colour',
+];
 foreach ($colours as $classname => $stringkey) {
     $colour = get_config('block_completion_progress', $stringkey) ?:
         get_string($stringkey, 'block_completion_progress');

--- a/db/access.php
+++ b/db/access.php
@@ -24,50 +24,50 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$capabilities = array (
-    'block/completion_progress:overview' => array (
+$capabilities = [
+    'block/completion_progress:overview' => [
         'riskbitmask'   => RISK_PERSONAL,
         'captype'       => 'read',
         'contextlevel'  => CONTEXT_BLOCK,
-        'archetypes'    => array (
+        'archetypes'    => [
             'teacher'           => CAP_ALLOW,
             'editingteacher'    => CAP_ALLOW,
             'manager'           => CAP_ALLOW,
-            'coursecreator'     => CAP_ALLOW
-        )
-    ),
+            'coursecreator'     => CAP_ALLOW,
+        ],
+    ],
 
-    'block/completion_progress:showbar' => array (
+    'block/completion_progress:showbar' => [
         'captype'       => 'read',
         'contextlevel'  => CONTEXT_BLOCK,
-        'archetypes'    => array (
+        'archetypes'    => [
             'teacher'           => CAP_ALLOW,
             'editingteacher'    => CAP_ALLOW,
             'student'           => CAP_ALLOW,
-        )
-    ),
+        ],
+    ],
 
-    'block/completion_progress:addinstance' => array(
+    'block/completion_progress:addinstance' => [
         'riskbitmask' => RISK_PERSONAL,
         'captype' => 'write',
         'contextlevel' => CONTEXT_BLOCK,
-        'archetypes' => array(
+        'archetypes' => [
             'editingteacher' => CAP_ALLOW,
             'manager'        => CAP_ALLOW,
-            'coursecreator'  => CAP_ALLOW
-        ),
+            'coursecreator'  => CAP_ALLOW,
+        ],
 
-        'clonepermissionsfrom' => 'moodle/site:manageblocks'
-    ),
+        'clonepermissionsfrom' => 'moodle/site:manageblocks',
+    ],
 
-    'block/completion_progress:myaddinstance' => array(
+    'block/completion_progress:myaddinstance' => [
         'riskbitmask' => RISK_PERSONAL,
         'captype' => 'read',
         'contextlevel' => CONTEXT_SYSTEM,
-        'archetypes' => array(
-            'user' => CAP_ALLOW
-        ),
+        'archetypes' => [
+            'user' => CAP_ALLOW,
+        ],
 
-        'clonepermissionsfrom' => 'moodle/my:manageblocks'
-    ),
-);
+        'clonepermissionsfrom' => 'moodle/my:manageblocks',
+    ],
+];

--- a/edit_form.php
+++ b/edit_form.php
@@ -57,12 +57,12 @@ class block_completion_progress_edit_form extends block_edit_form {
 
         // Control order of items in Progress Bar.
         $expectedbystring = get_string('completionexpected', 'completion');
-        $options = array(
+        $options = [
             completion_progress::ORDERBY_TIME   => get_string('config_orderby_due_time',
                 'block_completion_progress', $expectedbystring),
             completion_progress::ORDERBY_COURSE => get_string('config_orderby_course_order',
                 'block_completion_progress'),
-        );
+        ];
         $label = get_string('config_orderby', 'block_completion_progress');
         $mform->addElement('select', 'config_orderby', $label, $options);
         $mform->setDefault('config_orderby', defaults::ORDERBY);
@@ -78,16 +78,16 @@ class block_completion_progress_edit_form extends block_edit_form {
         }
         if (!$allwithexpected) {
             $warningstring = get_string('not_all_expected_set', 'block_completion_progress', $expectedbystring);
-            $expectedwarning = html_writer::tag('div', $warningstring, array('class' => 'warning'));
+            $expectedwarning = html_writer::tag('div', $warningstring, ['class' => 'warning']);
             $mform->addElement('static', $expectedwarning, '', $expectedwarning);
         }
 
         // Control how long bars wrap/scroll.
-        $options = array(
+        $options = [
             'squeeze' => get_string('config_squeeze', 'block_completion_progress'),
             'scroll' => get_string('config_scroll', 'block_completion_progress'),
             'wrap' => get_string('config_wrap', 'block_completion_progress'),
-        );
+        ];
         $label = get_string('config_longbars', 'block_completion_progress');
         $mform->addElement('select', 'config_longbars', $label, $options);
         $defaultlongbars = get_config('block_completion_progress', 'defaultlongbars') ?: defaults::LONGBARS;
@@ -98,8 +98,8 @@ class block_completion_progress_edit_form extends block_edit_form {
         if (get_config('block_completion_progress', 'forceiconsinbar') !== "1") {
             $mform->addElement('selectyesno', 'config_progressBarIcons',
                                get_string('config_icons', 'block_completion_progress').' '.
-                               $OUTPUT->pix_icon('tick', '', 'block_completion_progress', array('class' => 'iconOnConfig')).
-                               $OUTPUT->pix_icon('cross', '', 'block_completion_progress', array('class' => 'iconOnConfig')));
+                               $OUTPUT->pix_icon('tick', '', 'block_completion_progress', ['class' => 'iconOnConfig']).
+                               $OUTPUT->pix_icon('cross', '', 'block_completion_progress', ['class' => 'iconOnConfig']));
             $mform->setDefault('config_progressBarIcons', defaults::PROGRESSBARICONS);
             $mform->addHelpButton('config_progressBarIcons', 'why_use_icons', 'block_completion_progress');
         }
@@ -114,7 +114,7 @@ class block_completion_progress_edit_form extends block_edit_form {
         $groups = groups_get_all_groups($COURSE->id);
         $groupings = groups_get_all_groupings($COURSE->id);
         if (!empty($groups) || !empty($groupings)) {
-            $options = array();
+            $options = [];
             $options['0'] = get_string('allparticipants');
             foreach ($groups as $group) {
                 $options['group-' . $group->id] = format_string($group->name);
@@ -138,10 +138,10 @@ class block_completion_progress_edit_form extends block_edit_form {
         $mform->setAdvanced('config_progressTitle', true);
 
         // Control which activities are included in the bar.
-        $options = array(
+        $options = [
             'activitycompletion' => get_string('config_activitycompletion', 'block_completion_progress'),
             'selectedactivities' => get_string('config_selectedactivities', 'block_completion_progress'),
-        );
+        ];
         $label = get_string('config_activitiesincluded', 'block_completion_progress');
         $mform->addElement('select', 'config_activitiesincluded', $label, $options);
         $mform->setDefault('config_activitiesincluded', defaults::ACTIVITIESINCLUDED);
@@ -151,10 +151,10 @@ class block_completion_progress_edit_form extends block_edit_form {
         // Check that there are activities to monitor.
         if (empty($activities)) {
             $warningstring = get_string('no_activities_config_message', 'block_completion_progress');
-            $activitieswarning = html_writer::tag('div', $warningstring, array('class' => 'warning'));
+            $activitieswarning = html_writer::tag('div', $warningstring, ['class' => 'warning']);
             $mform->addElement('static', '', '', $activitieswarning);
         } else {
-            $options = array();
+            $options = [];
             foreach ($activities as $activity) {
                 $options[$activity->type.'-'.$activity->instance] = format_string($activity->name);
             }

--- a/overview.php
+++ b/overview.php
@@ -50,11 +50,11 @@ $role     = optional_param('role', null, PARAM_INT);
 $download = optional_param('download', '', PARAM_ALPHA);
 
 // Determine course and context.
-$course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+$course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
 $context = context_course::instance($courseid);
 
 // Get specific block config and context.
-$block = $DB->get_record('block_instances', array('id' => $id), '*', MUST_EXIST);
+$block = $DB->get_record('block_instances', ['id' => $id], '*', MUST_EXIST);
 $blockcontext = context_block::instance($id);
 
 $notesallowed = !empty($CFG->enablenotes) && has_capability('moodle/notes:manage', $context);
@@ -65,14 +65,14 @@ $bulkoperations = has_capability('moodle/course:bulkmessaging', $context) && ($n
 $PAGE->set_course($course);
 $PAGE->set_url(
     '/blocks/completion_progress/overview.php',
-    array(
+    [
         'instanceid' => $id,
         'courseid'   => $courseid,
         'page'       => $page,
         'perpage'    => $perpage,
         'group'      => $group,
         'role'       => $role,
-    )
+    ]
 );
 $PAGE->set_context($context);
 $title = get_string('overview', 'block_completion_progress');
@@ -131,7 +131,7 @@ $sql = "SELECT DISTINCT r.id, r.name, r.shortname, r.archetype, r.sortorder
         ORDER BY r.sortorder";
 $params = ['contextid' => $context->id];
 $roles = role_fix_names($DB->get_records_sql($sql, $params), $context);
-$roleoptions = array(0 => get_string('allparticipants'));
+$roleoptions = [0 => get_string('allparticipants')];
 foreach ($roles as $rec) {
     if ($role === null && $rec->archetype === 'student') {
         $role = $rec->id;  // First student role is the default.
@@ -182,12 +182,12 @@ if ($roleoptions) {
 echo $output->container_end();
 
 // Form for messaging selected participants.
-$formattributes = array('action' => $CFG->wwwroot.'/user/action_redir.php', 'method' => 'post', 'id' => 'participantsform');
+$formattributes = ['action' => $CFG->wwwroot.'/user/action_redir.php', 'method' => 'post', 'id' => 'participantsform'];
 $formattributes['data-course-id'] = $course->id;
 $formattributes['data-table-unique-id'] = 'block-completion_progress-overview-' . $course->id;
 echo html_writer::start_tag('form', $formattributes);
-echo html_writer::empty_tag('input', array('type' => 'hidden', 'name' => 'sesskey', 'value' => sesskey()));
-echo html_writer::empty_tag('input', array('type' => 'hidden', 'name' => 'returnto', 'value' => s($PAGE->url->out(false))));
+echo html_writer::empty_tag('input', ['type' => 'hidden', 'name' => 'sesskey', 'value' => sesskey()]);
+echo html_writer::empty_tag('input', ['type' => 'hidden', 'name' => 'returnto', 'value' => s($PAGE->url->out(false))]);
 
 // Imitate a 3.9 dynamic table enough to fool the core_user/participants JS code, until
 // next time it changes again.
@@ -211,18 +211,18 @@ if ($table->totalrows > $perpage || $perpage == SHOW_ALL_PAGE_SIZE) {
     if ($perpage < SHOW_ALL_PAGE_SIZE) {
         $perpageurl->param('perpage', SHOW_ALL_PAGE_SIZE);
         echo $output->container(html_writer::link($perpageurl,
-            get_string('showall', '', $table->totalrows)), array(), 'showall');
+            get_string('showall', '', $table->totalrows)), [], 'showall');
     } else {
         $perpageurl->param('perpage', DEFAULT_PAGE_SIZE);
         echo $output->container(html_writer::link($perpageurl,
-            get_string('showperpage', '', DEFAULT_PAGE_SIZE)), array(), 'showall');
+            get_string('showperpage', '', DEFAULT_PAGE_SIZE)), [], 'showall');
     }
 }
 
 if ($bulkoperations) {
     echo '<br /><div class="form-inline m-1">';
 
-    $displaylist = array();
+    $displaylist = [];
     if ($messagingallowed) {
         $displaylist['#messageselect'] = get_string('messageselectadd');
     }
@@ -230,8 +230,8 @@ if ($bulkoperations) {
         $displaylist['#addgroupnote'] = get_string('addnewnote', 'notes');
     }
 
-    echo html_writer::tag('label', get_string("withselectedusers"), array('for' => 'formactionid'));
-    echo html_writer::select($displaylist, 'formaction', '', array('' => 'choosedots'), array('id' => 'formactionid'));
+    echo html_writer::tag('label', get_string("withselectedusers"), ['for' => 'formactionid']);
+    echo html_writer::select($displaylist, 'formaction', '', ['' => 'choosedots'], ['id' => 'formactionid']);
 
     echo '<input type="hidden" name="id" value="'.$course->id.'" />';
     echo '<noscript style="display:inline">';
@@ -251,7 +251,7 @@ echo $table->download_buttons();
 
 // Organise access to JS for progress bars.
 $PAGE->requires->js_call_amd('block_completion_progress/progressbar', 'init', [
-    'instances' => array($block->id),
+    'instances' => [$block->id],
 ]);
 
 echo $output->container_end();

--- a/settings.php
+++ b/settings.php
@@ -28,7 +28,7 @@ use block_completion_progress\defaults;
 
 if ($ADMIN->fulltree) {
 
-    $options = array(10 => 10, 12 => 12, 14 => 14, 16 => 16, 18 => 18, 20 => 20);
+    $options = [10 => 10, 12 => 12, 14 => 14, 16 => 16, 18 => 18, 20 => 20];
     $settings->add(new admin_setting_configselect('block_completion_progress/wrapafter',
         get_string('wrapafter', 'block_completion_progress'),
         '',
@@ -36,11 +36,11 @@ if ($ADMIN->fulltree) {
         $options)
     );
 
-    $options = array(
+    $options = [
         'squeeze' => get_string('config_squeeze', 'block_completion_progress'),
         'scroll' => get_string('config_scroll', 'block_completion_progress'),
         'wrap' => get_string('config_wrap', 'block_completion_progress'),
-    );
+    ];
     $settings->add(new admin_setting_configselect('block_completion_progress/defaultlongbars',
         get_string('defaultlongbars', 'block_completion_progress'),
         '',
@@ -48,10 +48,10 @@ if ($ADMIN->fulltree) {
         $options)
     );
 
-    $options = array(
+    $options = [
         'shortname' => get_string('shortname', 'block_completion_progress'),
-        'fullname' => get_string('fullname', 'block_completion_progress')
-    );
+        'fullname' => get_string('fullname', 'block_completion_progress'),
+    ];
     $settings->add(new admin_setting_configselect('block_completion_progress/coursenametoshow',
         get_string('coursenametoshow', 'block_completion_progress'),
         '',

--- a/tests/assign_completion_test.php
+++ b/tests/assign_completion_test.php
@@ -59,7 +59,7 @@ class assign_completion_test extends \block_completion_progress\tests\completion
             'completionsubmit' => 1,
             'completionusegrade' => 1,
             'completionpassgrade' => 0,
-            'completion' => COMPLETION_TRACKING_AUTOMATIC
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
         ]);
         $cm = get_coursemodule_from_instance('assign', $instance->id);
         $context = \context_module::instance($cm->id);
@@ -209,8 +209,8 @@ class assign_completion_test extends \block_completion_progress\tests\completion
      */
     public function teamsubmission_provider(): array {
         return [
-            'one-per-group' => [ 0, ],
-            'per-member'    => [ 1, ],
+            'one-per-group' => [ 0 ],
+            'per-member'    => [ 1 ],
         ];
     }
 
@@ -321,7 +321,7 @@ class assign_completion_test extends \block_completion_progress\tests\completion
                 'itemid' => file_get_unused_draft_itemid(),
                 'text' => 'Text',
                 'format' => FORMAT_HTML,
-            ]
+            ],
         ], $notices);
 
         $assign->submit_for_grading((object) [

--- a/tests/general_test.php
+++ b/tests/general_test.php
@@ -44,6 +44,12 @@ use block_completion_progress\defaults;
  */
 class general_test extends \advanced_testcase {
     /**
+     * Course.
+     * @var stdClass
+     */
+    private $course;
+
+    /**
      * Teacher users.
      * @var array
      */
@@ -131,7 +137,7 @@ class general_test extends \advanced_testcase {
         $assign = $this->create_assign_instance([
           'submissiondrafts' => 0,
           'completionsubmit' => 1,
-          'completion' => COMPLETION_TRACKING_AUTOMATIC
+          'completion' => COMPLETION_TRACKING_AUTOMATIC,
         ]);
 
         $gradeitem = \grade_item::fetch(['courseid' => $this->course->id,
@@ -340,11 +346,11 @@ class general_test extends \advanced_testcase {
 
         $pageinstance = $this->getDataGenerator()->create_module('page', [
             'course' => $this->course->id,
-            'completion' => COMPLETION_TRACKING_MANUAL
+            'completion' => COMPLETION_TRACKING_MANUAL,
         ]);
         $labelinstance = $this->getDataGenerator()->create_module('label', [
             'course' => $this->course->id,
-            'completion' => COMPLETION_TRACKING_MANUAL
+            'completion' => COMPLETION_TRACKING_MANUAL,
         ]);
 
         $modinfo = get_fast_modinfo($this->course);

--- a/tests/overview_test.php
+++ b/tests/overview_test.php
@@ -149,7 +149,7 @@ class overview_test extends \advanced_testcase {
         $assign = $this->create_assign_instance([
           'submissiondrafts' => 0,
           'completionsubmit' => 1,
-          'completion' => COMPLETION_TRACKING_AUTOMATIC
+          'completion' => COMPLETION_TRACKING_AUTOMATIC,
         ]);
 
         $PAGE->set_url('/');
@@ -237,12 +237,12 @@ class overview_test extends \advanced_testcase {
 
         $page1 = $generator->create_module('page', [
             'course' => $this->course->id,
-            'completion' => COMPLETION_TRACKING_MANUAL
+            'completion' => COMPLETION_TRACKING_MANUAL,
         ]);
         $page1cm = get_coursemodule_from_id('page', $page1->cmid);
         $page2 = $generator->create_module('page', [
             'course' => $this->course->id,
-            'completion' => COMPLETION_TRACKING_MANUAL
+            'completion' => COMPLETION_TRACKING_MANUAL,
         ]);
         $page2cm = get_coursemodule_from_id('page', $page2->cmid);
 

--- a/tests/overview_test.php
+++ b/tests/overview_test.php
@@ -43,6 +43,12 @@ use block_completion_progress\defaults;
  */
 class overview_test extends \advanced_testcase {
     /**
+     * Course.
+     * @var object
+     */
+    private $course;
+
+    /**
      * Teacher users.
      * @var array
      */

--- a/tests/quiz_completion_test.php
+++ b/tests/quiz_completion_test.php
@@ -53,10 +53,10 @@ class quiz_completion_test extends \block_completion_progress\tests\completion_t
      */
     public function grademethod_provider(): array {
         return [
-            'QUIZ_GRADEHIGHEST' => [ QUIZ_GRADEHIGHEST, ],
-            'QUIZ_GRADEAVERAGE' => [ QUIZ_GRADEAVERAGE, ],
-            'QUIZ_ATTEMPTFIRST' => [ QUIZ_ATTEMPTFIRST, ],
-            'QUIZ_ATTEMPTLAST' => [ QUIZ_ATTEMPTLAST, ],
+            'QUIZ_GRADEHIGHEST' => [ QUIZ_GRADEHIGHEST ],
+            'QUIZ_GRADEAVERAGE' => [ QUIZ_GRADEAVERAGE ],
+            'QUIZ_ATTEMPTFIRST' => [ QUIZ_ATTEMPTFIRST ],
+            'QUIZ_ATTEMPTLAST' => [ QUIZ_ATTEMPTLAST ],
         ];
     }
 

--- a/tests/workshop_completion_test.php
+++ b/tests/workshop_completion_test.php
@@ -144,9 +144,9 @@ class workshop_completion_test extends \block_completion_progress\tests\completi
 
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_workshop');
 
-        $id = $generator->create_submission($workshop->id, $student->id, array(
+        $id = $generator->create_submission($workshop->id, $student->id, [
             'title' => 'Submission',
-        ));
+        ]);
         return $DB->get_record('workshop_submissions', ['id' => $id]);
     }
 


### PR DESCRIPTION
While the long date format is useful when over viewing course completion, a short date is more export friendly (easier handled by Excel, ....)

Additional changes:

- Fix .[PHP Deprecated](https://github.com/ewallah/moodle-block_completion_progress/actions/runs/7151845433/job/19476549680#step:15:15):  Creation of dynamic property block_completion_progress\general_test::$course is deprecated in /home/runner/work/moodle-block_completion_progress/moodle-block_completion_progress/moodle/blocks/completion_progress/tests/general_test.php on line 73 
- Update [moodle-plugin_ci](https://github.com/ewallah/moodle-block_completion_progress/actions/runs/7151845433/workflow#L70) from 3 to 4
- Fix [codechecker ](https://github.com/ewallah/moodle-block_completion_progress/actions/runs/7151845433/job/19476549680#step:10:1)warnings. Done by running the command `moodle-plugin-ci.phar phpcbf blocks/completion_progress`