### PR TITLE
Add preselection of group/grouping filter on overview page

### DIFF
--- a/block_completion_progress.php
+++ b/block_completion_progress.php
@@ -290,6 +290,14 @@ class block_completion_progress extends block_base {
         // Allow teachers to access the overview page.
         if (has_capability('block/completion_progress:overview', $this->context)) {
             $parameters = ['instanceid' => $this->instance->id, 'courseid' => $COURSE->id];
+            if(!empty($this->config->preselectgroup) && !empty($this->config->group)){
+                $group = $this->config->group;
+                if (substr($group, 0, 6) === 'group-') {
+                    $parameters['group'] = substr($group, 6);
+                } elseif (substr($group, 0, 9) === 'grouping-') {
+                    $parameters['group'] = 'g' . substr($group, 9);
+                }
+            }
             $url = new moodle_url('/blocks/completion_progress/overview.php', $parameters);
             $label = get_string('overview', 'block_completion_progress');
             $options = ['class' => 'overviewButton'];

--- a/edit_form.php
+++ b/edit_form.php
@@ -128,6 +128,11 @@ class block_completion_progress_edit_form extends block_edit_form {
             $mform->setAdvanced('config_group', true);
         }
 
+        $mform->addElement('advcheckbox', 'config_preselectgroup',
+                           get_string('config_preselectgroup', 'block_completion_progress'), ' ');
+        $mform->hideif('config_preselectgroup', 'config_group', 'eq', '0');
+        $mform->setAdvanced('config_preselectgroup', true);
+
         // Set block instance title.
         $mform->addElement('text', 'config_progressTitle',
                            get_string('config_title', 'block_completion_progress'));

--- a/lang/en/block_completion_progress.php
+++ b/lang/en/block_completion_progress.php
@@ -42,6 +42,7 @@ $string['config_orderby'] = 'Order bar by';
 $string['config_orderby_course_order'] = 'Ordering in course';
 $string['config_orderby_due_time'] = 'Time using "{$a}" date';
 $string['config_percentage'] = 'Show percentage to students';
+$string['config_preselectgroup'] = 'Preselect group/grouping on overview page';
 $string['config_scroll'] = 'Scroll';
 $string['config_selectactivities'] = 'Select activities';
 $string['config_selectedactivities'] = 'Selected activities';


### PR DESCRIPTION
Hi,

This commit adds support for preselecting the group/grouping filter on the overview page. The preselection is only applied if the Completion Progress block is configured for group or grouping mode.

regards
Mario